### PR TITLE
feat: byte_size(), shrink_to_fit() and ops by-ref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bloom2"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Dom Dwyer <dom@itsallbroken.com>"]
 edition = "2018"
 

--- a/src/bitmap/compressed_bitmap.rs
+++ b/src/bitmap/compressed_bitmap.rs
@@ -77,6 +77,12 @@ impl CompressedBitmap {
         }
     }
 
+    pub fn size(&self) -> usize {
+        (self.block_map.capacity() * std::mem::size_of::<usize>())
+            + (self.bitmap.capacity() * std::mem::size_of::<usize>())
+            + std::mem::size_of_val(self)
+    }
+
     /// Reduces the allocated memory usage of the filter to the minimum required
     /// for the current filter contents.
     ///
@@ -85,7 +91,8 @@ impl CompressedBitmap {
     ///
     /// See [`Vec::shrink_to_fit`](std::vec::Vec::shrink_to_fit).
     pub fn shrink_to_fit(&mut self) {
-        self.bitmap.shrink_to_fit()
+        self.bitmap.shrink_to_fit();
+        self.block_map.shrink_to_fit();
         // TODO: remove 0 blocks
     }
 
@@ -276,6 +283,10 @@ impl Bitmap for CompressedBitmap {
 
     fn set(&mut self, key: usize, value: bool) {
         self.set(key, value)
+    }
+
+    fn byte_size(&self) -> usize {
+        self.size()
     }
 }
 

--- a/src/bitmap/compressed_bitmap.rs
+++ b/src/bitmap/compressed_bitmap.rs
@@ -54,7 +54,7 @@ impl CompressedBitmap {
         // max_key number of bits.
         let blocks = index_for_key(max_key);
 
-        // FIgure out how many usize elements are needed to represent blocks
+        // Figure out how many usize elements are needed to represent blocks
         // number of bitmaps.
         let num_blocks = match blocks % (mem::size_of::<usize>() * 8) {
             0 => index_for_key(blocks),

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -121,7 +121,7 @@ fn key_size_to_bits(k: FilterSize) -> usize {
     (2 as usize).pow(8 * k as u32)
 }
 
-/// A fast, memory efficient bloom filter.
+/// A fast, memory efficient, sparse bloom filter.
 ///
 /// Most users can quickly initialise a `Bloom2` instance by calling
 /// `Bloom2::default()` and start inserting anything that implements the
@@ -141,6 +141,12 @@ fn key_size_to_bits(k: FilterSize) -> usize {
 /// lookup, change the hashing algorithm, memory size of the filter, etc, a
 /// [`BloomFilterBuilder`] can be used to initialise a `Bloom2` instance with
 /// the desired properties.
+///
+/// The sparse nature of this filter trades a small amount of insert performance
+/// for decreased memory usage. For filters initialised infrequently and held
+/// for a meaningful duration of time, this is almost always worth the
+/// marginally increased insert latency. When testing performance, be sure to
+/// use a release build - there's a significant performance difference!
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bloom2<H, B, T>
@@ -184,6 +190,8 @@ where
     ///
     /// Any subsequent calls to [`contains`](Bloom2::contains) for the same
     /// `data` will always return true.
+    ///
+    /// Insertion is significantly faster in release builds.
     ///
     /// The `data` provided can be anything that implements the [`Hash`] trait,
     /// for example:

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -28,7 +28,7 @@ pub trait Bitmap {
 ///                     .size(FilterSize::KeyBytes2)
 ///                     .build();
 ///
-/// filter.insert("success!");
+/// filter.insert(&"success!");
 /// ```
 pub struct BloomFilterBuilder<H, B>
 where
@@ -131,8 +131,8 @@ fn key_size_to_bits(k: FilterSize) -> usize {
 /// use bloom2::Bloom2;
 ///
 /// let mut b = Bloom2::default();
-/// b.insert("hello 🐐");
-/// assert!(b.contains("hello 🐐"));
+/// b.insert(&"hello 🐐");
+/// assert!(b.contains(&"hello 🐐"));
 /// ```
 ///
 /// Initialising a `Bloom2` this way uses some [sensible
@@ -169,7 +169,7 @@ where
 /// use bloom2::BloomFilterBuilder;
 ///
 /// let mut b = BloomFilterBuilder::default().build();
-/// # b.insert(42);
+/// # b.insert(&42);
 /// ```
 impl<T> std::default::Default for Bloom2<RandomState, CompressedBitmap, T>
 where
@@ -200,17 +200,17 @@ where
     /// use bloom2::Bloom2;
     ///
     /// let mut b = Bloom2::default();
-    /// b.insert("hello 🐐");
-    /// assert!(b.contains("hello 🐐"));
+    /// b.insert(&"hello 🐐");
+    /// assert!(b.contains(&"hello 🐐"));
     ///
     /// let mut b = Bloom2::default();
-    /// b.insert(vec!["fox", "cat", "banana"]);
-    /// assert!(b.contains(vec!["fox", "cat", "banana"]));
+    /// b.insert(&vec!["fox", "cat", "banana"]);
+    /// assert!(b.contains(&vec!["fox", "cat", "banana"]));
     ///
     /// let mut b = Bloom2::default();
     /// let data: [u8; 4] = [1, 2, 3, 42];
-    /// b.insert(data);
-    /// assert!(b.contains(data));
+    /// b.insert(&data);
+    /// assert!(b.contains(&data));
     /// ```
     ///
     /// As well as structs if they implement the [`Hash`] trait, which be
@@ -230,10 +230,10 @@ where
     ///     email: "dom@itsallbroken.com".to_string(),
     /// };
     ///
-    /// b.insert(&user);
-    /// assert!(b.contains(&user));
+    /// b.insert(&&user);
+    /// assert!(b.contains(&&user));
     /// ```
-    pub fn insert(&mut self, data: T) {
+    pub fn insert(&mut self, data: &'_ T) {
         // Generate a hash (u64) value for data
         let mut hasher = self.hasher.build_hasher();
         data.hash(&mut hasher);
@@ -252,7 +252,7 @@ where
     /// If `contains` returns true, `hash` has **probably** been inserted
     /// previously. If `contains` returns false, `hash` has **definitely not**
     /// been inserted into the filter.
-    pub fn contains(&mut self, data: T) -> bool {
+    pub fn contains(&mut self, data: &'_ T) -> bool {
         // Generate a hash (u64) value for data
         let mut hasher = self.hasher.build_hasher();
         data.hash(&mut hasher);
@@ -325,19 +325,19 @@ mod tests {
         let mut b = Bloom2::default();
         assert_eq!(b.key_size, FilterSize::KeyBytes2);
 
-        b.insert(42);
-        assert!(b.contains(42));
+        b.insert(&42);
+        assert!(b.contains(&42));
     }
 
     #[quickcheck]
     fn test_default_prop(vals: Vec<u16>) {
         let mut b = Bloom2::default();
         for v in &vals {
-            b.insert(*v);
+            b.insert(&*v);
         }
 
         for v in &vals {
-            assert!(b.contains(*v));
+            assert!(b.contains(&*v));
         }
     }
 
@@ -346,7 +346,7 @@ mod tests {
         let mut b = new_test_bloom();
         b.hasher.return_hash = 12345678901234567890;
 
-        b.insert([1, 2, 3, 4]);
+        b.insert(&[1, 2, 3, 4]);
         assert_eq!(
             b.bitmap.set_calls,
             vec![
@@ -361,7 +361,7 @@ mod tests {
             ]
         );
 
-        b.contains([1, 2, 3, 4]);
+        b.contains(&[1, 2, 3, 4]);
         assert_eq!(
             b.bitmap.get_calls.into_inner(),
             vec![171, 84, 169, 140, 235, 31, 10, 210]
@@ -374,7 +374,7 @@ mod tests {
         b.key_size = FilterSize::KeyBytes2;
         b.hasher.return_hash = 12345678901234567890;
 
-        b.insert([1, 2, 3, 4]);
+        b.insert(&[1, 2, 3, 4]);
 
         assert_eq!(
             b.bitmap.set_calls,
@@ -390,9 +390,9 @@ mod tests {
                 .size(FilterSize::KeyBytes4)
                 .build();
 
-        bloom_filter.insert("a");
-        bloom_filter.insert("b");
-        bloom_filter.insert("c");
-        bloom_filter.insert("d");
+        bloom_filter.insert(&"a");
+        bloom_filter.insert(&"b");
+        bloom_filter.insert(&"c");
+        bloom_filter.insert(&"d");
     }
 }


### PR DESCRIPTION
Allow insert()/contains() to use references, and expose memory usage of the filter.

---

* docs: mention release build performance diff (4fe31f6)
      
      It's significant!

* refactor: elements by-ref (949bd90)
      
      Allow non-copy types to be used without cloning, by accepting refs to
      the elements to be inserted/checked.
      
      BREAKING CHANGE: you now have to pass by ref for insert() and contains()

* feat: byte_size() & shrink_to_fit() methods (628db4d)
      
      Allow the caller to observe the current memory usage of the filter, in
      bytes, and optimise it by calling shrink_to_fit() on the underlying
      vectors.

* chore: bump version to 0.3.0 (0665102)
      