### PR TITLE
refactor: no &mut for contains()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bloom2"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Dom Dwyer <dom@itsallbroken.com>"]
 edition = "2018"
 

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -258,7 +258,7 @@ where
     /// If `contains` returns true, `hash` has **probably** been inserted
     /// previously. If `contains` returns false, `hash` has **definitely not**
     /// been inserted into the filter.
-    pub fn contains(&mut self, data: &'_ T) -> bool {
+    pub fn contains(&self, data: &'_ T) -> bool {
         // Generate a hash (u64) value for data
         let mut hasher = self.hasher.build_hasher();
         data.hash(&mut hasher);


### PR DESCRIPTION
This shouldn't be &mut!

---

* refactor: &self for contains() (d3006d0)
      
      There's no need for a mutable reference for contains().

* chore: bump version to 0.3.1 (3005c9d)
      