### PR TITLE
Tell docs.rs to build all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,6 @@ repository = "https://github.com/domodwyer/bloom2"
 keywords = ["bloom", "filter", "probabilistic", "set", "bitmap"]
 categories = ["caching", "compression", "data-structures"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ harness = false
 
 [lib]
 bench = false
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Mostly so that readers of the documentation on docs.rs can see for which items the `serde` traits have been implemented.

`cargo doc` (what's on docs.rs now, note there are 5 trait impls shown):

<img width="560" alt="Screenshot of bloom2::Bloom2 HTML docs with 5 trait impls in the sidebar" src="https://github.com/user-attachments/assets/4df27a4d-747d-4012-9371-e91ffb5cba18">

`cargo doc --all-features` (what will be on docs.rs after this change is released, note there are 7 trait impls shown): 

<img width="556" alt="Screenshot of bloom2::Bloom2 HTML docs with 7 trait impls in the sidebar" src="https://github.com/user-attachments/assets/d9339333-d14e-4d55-a5b2-6d818da02137">

