### PR TITLE
Make `hasher` usable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "0.5"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 serde_json = "1.0"
+twox-hash = "1"
 
 [[bench]]
 name = "bench"

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -296,7 +296,7 @@ fn bytes_to_usize_key<'a, I: IntoIterator<Item = &'a u8>>(bytes: I) -> usize {
 mod tests {
     use super::*;
     use quickcheck_macros::quickcheck;
-    use std::cell::RefCell;
+    use std::{cell::RefCell, hash::BuildHasherDefault};
 
     #[derive(Debug, Clone, Default)]
     struct MockHasher {
@@ -434,5 +434,25 @@ mod tests {
         assert_eq!(bloom_filter.byte_size(), 8388920);
         bloom_filter.shrink_to_fit();
         assert_eq!(bloom_filter.byte_size(), 8388824);
+    }
+
+    #[test]
+    fn set_hasher() {
+        let mut bloom_filter: Bloom2<
+            BuildHasherDefault<twox_hash::XxHash64>,
+            CompressedBitmap,
+            i32,
+        > = BloomFilterBuilder::default()
+            .hasher(BuildHasherDefault::<twox_hash::XxHash64>::default())
+            .size(FilterSize::KeyBytes4)
+            .build();
+
+        for i in 0..10 {
+            bloom_filter.insert(&i);
+        }
+
+        for i in 0..10 {
+            assert!(bloom_filter.contains(&i), "did not contain {}", i);
+        }
     }
 }

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -29,8 +29,7 @@ pub trait Bitmap {
 /// use std::collections::hash_map::RandomState;
 /// use bloom2::{BloomFilterBuilder, FilterSize};
 ///
-/// let mut filter = BloomFilterBuilder::default()
-///                     .hasher(RandomState::default())
+/// let mut filter = BloomFilterBuilder::hasher(RandomState::default())
 ///                     .size(FilterSize::KeyBytes2)
 ///                     .build();
 ///
@@ -69,11 +68,6 @@ where
     H: BuildHasher,
     B: Bitmap,
 {
-    /// Set the hash algorithm.
-    pub fn hasher(self, hasher: H) -> Self {
-        Self { hasher, ..self }
-    }
-
     /// Set the bit storage (bitmap) for the bloom filter.
     ///
     /// # Safety
@@ -119,6 +113,19 @@ where
             key_size: size,
             bitmap: CompressedBitmap::new(key_size_to_bits(size)),
             ..self
+        }
+    }
+
+    /// Initialise a `BloomFilterBuilder` that unless changed, will construct a
+    /// `Bloom2` instance using a [2 byte key] and use the specified hasher.
+    ///
+    /// [2 byte key]: crate::FilterSize::KeyBytes2
+    pub fn hasher(hasher: H) -> Self {
+        let size = FilterSize::KeyBytes2;
+        Self {
+            hasher,
+            bitmap: CompressedBitmap::new(key_size_to_bits(size)),
+            key_size: size,
         }
     }
 }
@@ -442,8 +449,7 @@ mod tests {
             BuildHasherDefault<twox_hash::XxHash64>,
             CompressedBitmap,
             i32,
-        > = BloomFilterBuilder::default()
-            .hasher(BuildHasherDefault::<twox_hash::XxHash64>::default())
+        > = BloomFilterBuilder::hasher(BuildHasherDefault::<twox_hash::XxHash64>::default())
             .size(FilterSize::KeyBytes4)
             .build();
 


### PR DESCRIPTION
Currently, the only public way to construct a `BloomFilterBuilder`
is by using `BloomFilterBuilder::default()`, which only constructs
a `BloomFilterBuilder<RandomState, CompressedBitmap>`.

Then the `hasher` function takes a `hasher` of type `H`, which can
only ever be called with a `RandomState` as that's the only kind of
`BloomFilterBuilder` you can have.

So you can have a BloomFilterBuilder of any hasher you want, as long as
it's RandomState!

Thus, this test fails to compile:

```
error[E0308]: mismatched types
   --> src/bloom.rs:446:21
    |
446 |             .hasher(BuildHasherDefault::<twox_hash::XxHash64>::default())
    |              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `RandomState`, found `BuildHasherDefault<XxHash64>`
    |              |
    |              arguments to this method are incorrect
    |
    = note: expected struct `std::hash::RandomState`
               found struct `BuildHasherDefault<XxHash64>`
```

To fix this, I changed `hasher` into a constructor that otherwise uses the same values as in `default`-- let me know if you'd rather have a different solution :)