### PR TITLE
added bytes-based storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 tests/fixtures/*.actual.json
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ exclude = [".github"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
+bytes = { version = "1.9.0", optional = true, features = ["serde"] }
 
 [features]
-serde = ["dep:serde"]
+serde = ["dep:serde", "bytes/serde"]
+bytes = ["dep:bytes"]
 
 [dev-dependencies]
+bincode = "1.3"
 criterion = "0.5"
 paste = "1.0.15"
 proptest = { version = "1.5.0" }

--- a/README.md
+++ b/README.md
@@ -75,4 +75,8 @@ is not reusable in a different process; for serialised filters a different
 hasher should be used. By default, derived [`Hash`] implementation is not
 considered portable but a hand-wrote implementation can be.
 
+If you are using the `BytesBitmap` as your bitmap storage, it is recommended to use
+the `bincode` library due to performance reasons. In initial testing, using 
+`serde_json` was very slow to encode the bitmap.
+
 [`Hash`]: https://doc.rust-lang.org/stable/std/hash/trait.Hash.html#portability

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -208,6 +208,7 @@ pub fn insert_bench(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "bytes")]
 criterion_group!(
     benches,
     basic_bench,
@@ -215,4 +216,8 @@ criterion_group!(
     bitmap_bench,
     bytes_bitmap_bench
 );
+
+#[cfg(not(feature = "bytes"))]
+criterion_group!(benches, basic_bench, insert_bench, bitmap_bench,);
+
 criterion_main!(benches);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,6 +18,28 @@ pub fn bitmap_bench(c: &mut Criterion) {
     });
 }
 
+#[cfg(feature = "bytes")]
+pub fn bytes_bitmap_bench(c: &mut Criterion) {
+    let mut bloom = BytesBitmap::new_with_capacity(1024);
+
+    c.bench_function("bytes_bitmap_insert_true", |b| {
+        b.iter(|| bloom.set(42, true))
+    });
+    c.bench_function("bytes_bitmap_insert_false", |b| {
+        b.iter(|| bloom.set(42, false))
+    });
+    c.bench_function("bytes_bitmap_lookup_hit", |b| {
+        bloom.set(42, true);
+        b.iter(|| black_box(bloom.get(42)))
+    });
+    c.bench_function("bytes_bitmap_lookup_miss, different block", |b| {
+        b.iter(|| black_box(bloom.get(1)))
+    });
+    c.bench_function("bytes_bitmap_lookup miss, same block", |b| {
+        b.iter(|| black_box(bloom.get(43)))
+    });
+}
+
 pub fn basic_bench(c: &mut Criterion) {
     let mut bloom = Bloom2::default();
 
@@ -130,7 +152,45 @@ pub fn insert_bench(c: &mut Criterion) {
         )
     });
 
+    #[cfg(feature = "bytes")]
+    c.bench_function("bloom_bytes_insert_4_000_000", |b| {
+        b.iter_batched(
+            || {
+                BloomFilterBuilder::default()
+                    .with_bitmap::<BytesBitmap>()
+                    .size(bloom2::FilterSize::KeyBytes4)
+                    .build()
+            },
+            |mut bloom| {
+                for i in 0..4_000_000 {
+                    bloom.insert(black_box(&i));
+                }
+
+                black_box(bloom)
+            },
+            BatchSize::NumBatches(1),
+        )
+    });
+
     c.bench_function("bloom_vec_convert_4_000_000", |b| {
+        let mut bloom = BloomFilterBuilder::default()
+            .with_bitmap::<VecBitmap>()
+            .size(bloom2::FilterSize::KeyBytes4)
+            .build();
+
+        for i in 0..4_000_000 {
+            bloom.insert(black_box(&i));
+        }
+
+        b.iter_batched(
+            || bloom.clone(),
+            |bloom| black_box(bloom.compress()),
+            BatchSize::NumBatches(1),
+        )
+    });
+
+    #[cfg(feature = "bytes")]
+    c.bench_function("bloom_bytes_convert_4_000_000", |b| {
         let mut bloom = BloomFilterBuilder::default()
             .with_bitmap::<VecBitmap>()
             .size(bloom2::FilterSize::KeyBytes4)
@@ -148,5 +208,11 @@ pub fn insert_bench(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, basic_bench, insert_bench, bitmap_bench);
+criterion_group!(
+    benches,
+    basic_bench,
+    insert_bench,
+    bitmap_bench,
+    bytes_bitmap_bench
+);
 criterion_main!(benches);

--- a/src/bitmap/bytes.rs
+++ b/src/bitmap/bytes.rs
@@ -1,0 +1,164 @@
+use crate::bitmap::{bitmask_for_key, index_for_key};
+use crate::{Bitmap};
+#[cfg(feature = "bytes")]
+use bytes::{BufMut, Bytes, BytesMut};
+use std::convert::TryInto;
+
+/// A plain, heap-allocated, `O(1)` indexed bitmap using `bytes::BytesMut` for storage.
+///
+/// This type provide fast O(1) read and write operations, but trades O(n) space complexity for the
+/// additional performance.
+///
+/// The [BytesBitmap] representation is suitable for persistence without the need for serialisation;
+/// the output of [BytesBitmap::freeze()] can be used to construct a new instance. [Serde]
+/// serialisation is also implemented as a conveinence to enable serialisation to various formats.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg(feature = "bytes")]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BytesBitmap {
+    max_key: usize,
+    bitmap: BytesMut,
+}
+
+#[cfg(feature = "bytes")]
+impl BytesBitmap {
+    pub fn freeze(self) -> Bytes {
+        self.bitmap.freeze()
+    }
+
+    pub fn max_key(&self) -> usize {
+        self.max_key
+    }
+
+    pub fn from_bytes(bitmap: impl Into<Bytes>) -> Self {
+        let bitmap = bitmap.into();
+        Self {
+            max_key: bitmap.len() * 8,
+            bitmap: BytesMut::from(bitmap),
+        }
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl Bitmap for BytesBitmap {
+    fn new_with_capacity(max_key: usize) -> Self {
+        let size = (index_for_key(max_key) + 1) * size_of::<usize>();
+        let bytes = BytesMut::zeroed(size);
+
+        Self {
+            bitmap: bytes,
+            max_key,
+        }
+    }
+
+    fn set(&mut self, key: usize, value: bool) {
+        let offset = index_for_key(key);
+        let byte_offset = offset * size_of::<usize>();
+
+        let slice = &mut self.bitmap[byte_offset..byte_offset + size_of::<usize>()];
+        let mut num = usize::from_ne_bytes(slice.try_into().unwrap());
+
+        if value {
+            num |= bitmask_for_key(key);
+        } else {
+            num &= !bitmask_for_key(key);
+        }
+
+        slice.copy_from_slice(&num.to_ne_bytes());
+    }
+
+    fn get(&self, key: usize) -> bool {
+        let offset = index_for_key(key);
+        let byte_offset = offset * size_of::<usize>();
+        let slice = &self.bitmap[byte_offset..byte_offset + size_of::<usize>()];
+        let num = usize::from_ne_bytes(slice.try_into().unwrap());
+        num & bitmask_for_key(key) != 0
+    }
+
+    fn byte_size(&self) -> usize {
+        self.bitmap.len()
+    }
+    
+    fn or(&self, other: &Self) -> Self {
+        assert_eq!(self.bitmap.len(), other.bitmap.len());
+
+        let mut result = BytesMut::with_capacity(self.bitmap.len());
+        let chunks = self
+            .bitmap
+            .chunks_exact(size_of::<usize>())
+            .zip(other.bitmap.chunks_exact(size_of::<usize>()));
+
+        for (a_chunk, b_chunk) in chunks {
+            let a = usize::from_ne_bytes(a_chunk.try_into().unwrap());
+            let b = usize::from_ne_bytes(b_chunk.try_into().unwrap());
+            result.put_slice(&(a | b).to_ne_bytes());
+        }
+
+        Self {
+            bitmap: result,
+            max_key: self.max_key,
+        }
+    }
+}
+
+#[cfg(feature = "bytes")]
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    const MAX_KEY: usize = 1028;
+
+    proptest! {
+        #[test]
+        fn prop_insert_contains(
+            values in prop::collection::hash_set(0..MAX_KEY, 0..20),
+        ) {
+            let mut b = BytesBitmap::new_with_capacity(MAX_KEY);
+
+            for v in &values {
+                b.set(*v, true);
+            }
+
+            // Ensure all values are equal in the test range.
+            for i in 0..MAX_KEY {
+                assert_eq!(b.get(i), values.contains(&i));
+            }
+        }
+
+        #[test]
+        fn prop_or(
+            a in prop::collection::vec(0..MAX_KEY, 0..20),
+            b in prop::collection::vec(0..MAX_KEY, 0..20),
+        ) {
+            let mut a_bitmap = BytesBitmap::new_with_capacity(MAX_KEY);
+            let mut b_bitmap = BytesBitmap::new_with_capacity(MAX_KEY);
+            let mut combined_bitmap = BytesBitmap::new_with_capacity(MAX_KEY);
+
+            for v in a.iter() {
+                a_bitmap.set(*v, true);
+                combined_bitmap.set(*v, true);
+            }
+
+            for v in b.iter() {
+                b_bitmap.set(*v, true);
+                combined_bitmap.set(*v, true);
+            }
+
+            let union = a_bitmap.or(&b_bitmap);
+
+            // Invariant: the union and the combined construction must be equal.
+            assert_eq!(union, combined_bitmap);
+
+            // Invariant: the key space contains true entries only when the
+            // value appears in a or b.
+            for i in 0..MAX_KEY {
+                assert_eq!(union.get(i), a_bitmap.get(i) || b_bitmap.get(i));
+
+                // Invariant: the key presence matches the combined bitmap.
+                assert_eq!(union.get(i), combined_bitmap.get(i));
+            }
+        }
+    }
+}

--- a/src/bitmap/bytes.rs
+++ b/src/bitmap/bytes.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "bytes")]
+
 use std::convert::TryInto;
 
-#[cfg(feature = "bytes")]
 use bytes::{BufMut, Bytes, BytesMut};
 
 use crate::{
@@ -19,14 +20,12 @@ use crate::{
 /// construct a new instance. [Serde] serialisation is also implemented as a
 /// conveinence to enable serialisation to various formats.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg(feature = "bytes")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BytesBitmap {
     max_key: usize,
     bitmap: BytesMut,
 }
 
-#[cfg(feature = "bytes")]
 impl BytesBitmap {
     pub fn freeze(self) -> Bytes {
         self.bitmap.freeze()
@@ -45,7 +44,6 @@ impl BytesBitmap {
     }
 }
 
-#[cfg(feature = "bytes")]
 impl Bitmap for BytesBitmap {
     fn new_with_capacity(max_key: usize) -> Self {
         let size = (index_for_key(max_key) + 1) * size_of::<usize>();
@@ -107,7 +105,6 @@ impl Bitmap for BytesBitmap {
     }
 }
 
-#[cfg(feature = "bytes")]
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;

--- a/src/bitmap/bytes.rs
+++ b/src/bitmap/bytes.rs
@@ -1,17 +1,23 @@
-use crate::bitmap::{bitmask_for_key, index_for_key};
-use crate::{Bitmap};
-#[cfg(feature = "bytes")]
-use bytes::{BufMut, Bytes, BytesMut};
 use std::convert::TryInto;
 
-/// A plain, heap-allocated, `O(1)` indexed bitmap using `bytes::BytesMut` for storage.
+#[cfg(feature = "bytes")]
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::{
+    bitmap::{bitmask_for_key, index_for_key},
+    Bitmap,
+};
+
+/// A plain, heap-allocated, `O(1)` indexed bitmap using `bytes::BytesMut` for
+/// storage.
 ///
-/// This type provide fast O(1) read and write operations, but trades O(n) space complexity for the
-/// additional performance.
+/// This type provide fast O(1) read and write operations, but trades O(n) space
+/// complexity for the additional performance.
 ///
-/// The [BytesBitmap] representation is suitable for persistence without the need for serialisation;
-/// the output of [BytesBitmap::freeze()] can be used to construct a new instance. [Serde]
-/// serialisation is also implemented as a conveinence to enable serialisation to various formats.
+/// The [BytesBitmap] representation is suitable for persistence without the
+/// need for serialisation; the output of [BytesBitmap::freeze()] can be used to
+/// construct a new instance. [Serde] serialisation is also implemented as a
+/// conveinence to enable serialisation to various formats.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg(feature = "bytes")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -78,7 +84,7 @@ impl Bitmap for BytesBitmap {
     fn byte_size(&self) -> usize {
         self.bitmap.len()
     }
-    
+
     fn or(&self, other: &Self) -> Self {
         assert_eq!(self.bitmap.len(), other.bitmap.len());
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -4,9 +4,11 @@ mod bytes;
 mod compressed_bitmap;
 mod vec;
 
-pub use bytes::*;
 pub use compressed_bitmap::*;
 pub use vec::*;
+
+#[cfg(feature = "bytes")]
+pub use bytes::*;
 
 #[inline(always)]
 pub(crate) fn bitmask_for_key(key: usize) -> usize {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -1,7 +1,10 @@
 //! Bitmap implementations for the backing storage of a [`Bloom2`](crate::Bloom2).
 
+mod bytes;
 mod compressed_bitmap;
 mod vec;
+
+pub use bytes::*;
 pub use compressed_bitmap::*;
 pub use vec::*;
 

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,6 +1,6 @@
-use crate::{bitmap::CompressedBitmap, FilterSize, VecBitmap};
 #[cfg(feature = "bytes")]
 use crate::bitmap::BytesBitmap;
+use crate::{bitmap::CompressedBitmap, FilterSize, VecBitmap};
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
@@ -446,10 +446,9 @@ mod tests {
     #[cfg(feature = "bytes")]
     #[test]
     fn test_with_bytesbitmap() {
-        let mut b: Bloom2<RandomState, BytesBitmap, i32> =
-            BloomFilterBuilder::default()
-                .with_bitmap::<BytesBitmap>()
-                .build();
+        let mut b: Bloom2<RandomState, BytesBitmap, i32> = BloomFilterBuilder::default()
+            .with_bitmap::<BytesBitmap>()
+            .build();
         b.insert(&42);
         assert!(b.contains(&42));
     }
@@ -725,9 +724,7 @@ mod tests {
     where
         B: Bitmap,
     {
-        let mut b = BloomFilterBuilder::default()
-            .with_bitmap::<B>()
-            .build();
+        let mut b = BloomFilterBuilder::default().with_bitmap::<B>().build();
 
         let mut control: HashSet<usize, RandomState> = HashSet::default();
         for op in ops {

--- a/src/bloom.rs
+++ b/src/bloom.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "bytes")]
-use crate::bitmap::BytesBitmap;
 use crate::{bitmap::CompressedBitmap, FilterSize, VecBitmap};
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
@@ -370,6 +368,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "bytes")]
+    use crate::bitmap::BytesBitmap;
+
     use proptest::prelude::*;
     use quickcheck_macros::quickcheck;
 


### PR DESCRIPTION
This is the initial PR for `Bytes`-based storage. I'm not 100% sure if there is an API change, since I reconfigured `Default` to accept any bitmap data type.

`serde_json` is very slow to encode `BytesBitmap` (re: ~75s) versus `bincode` (re: ~150ms), so `bincode` is used in the tests.

Resolves: #16 